### PR TITLE
add initial value for freezer multiplier

### DIFF
--- a/contracts/FreezerBase.sol
+++ b/contracts/FreezerBase.sol
@@ -32,7 +32,8 @@ abstract contract FreezerBase is
     function __FreezerBase_init() internal onlyInitializing {
         StakingPool = IStakingPool(0x6F42895f37291ec45f0A307b155229b923Ff83F1);
         GhnyToken = IGhny(0xa045E37a0D1dd3A45fefb8803D22457abc0A728a);
-        freezingMultiplier = 70;
+        // total multiplier of 4x
+        freezingMultiplier = 300;
         stopped = false;
 
         __ReentrancyGuard_init();

--- a/test/FreezerV2.ts
+++ b/test/FreezerV2.ts
@@ -71,9 +71,9 @@ describe("FreezerV2", function () {
         const totalDepositAmount = await FreezerInstance.totalFreezedAmount();
 
         expect(participant.deposited).to.be.greaterThan(depositAmount.mul(2));
-        expect(participant.honeyRewardMask).to.equal(62243800000);
+        expect(participant.honeyRewardMask).to.equal(146456000000);
         expect(participant.level).to.equal(0);
-        expect(totalDepositAmount).to.equal(depositAmount.mul(2).add(62243800000))
+        expect(totalDepositAmount).to.equal(depositAmount.mul(2).add(146456000000))
         expect(participantBefore.startTime).to.equal(participant.startTime)
     })
 
@@ -97,13 +97,13 @@ describe("FreezerV2", function () {
         expect(participant.level).to.equal(0);
 
         expect(participant2.deposited).to.equal(depositAmount2);
-        expect(participant2.honeyRewardMask).to.equal(93365530000);
+        expect(participant2.honeyRewardMask).to.equal(219683600000);
         expect(participant2.level).to.equal(0);
 
         const balance = await FreezerInstance.balanceOf(await signer.getAddress());
         const balance2 = await FreezerInstance.balanceOf(await otherSigner.getAddress());
 
-        expect(balance).to.equal(depositAmount.add(93365530000));
+        expect(balance).to.equal(depositAmount.add(219683600000));
         expect(balance2).to.equal(depositAmount2);
 
         const totalFreezedAmount = await FreezerInstance.totalFreezedAmount();
@@ -137,7 +137,7 @@ describe("FreezerV2", function () {
 
         const ghnyBalanceAfter = await GhnyToken.balanceOf(await signer.getAddress());
 
-        expect(ghnyBalanceAfter.sub(ghnyBalanceBefore)).to.equal(depositAmount.add(62243120000))
+        expect(ghnyBalanceAfter.sub(ghnyBalanceBefore)).to.equal(depositAmount.add(146454400000))
 
         const participant = await FreezerInstance.participantData(await signer.getAddress());
         const totalFreezedAmount = await FreezerInstance.totalFreezedAmount();
@@ -462,7 +462,7 @@ describe("FreezerV2", function () {
     it("Can set freezing multiplier", async function () {
 
         const [otherSigner] = await ethers.getSigners();
-        expect(await FreezerInstance.freezingMultiplier()).to.equal(70);
+        expect(await FreezerInstance.freezingMultiplier()).to.equal(300);
 
         await FreezerInstance.setFreezingMultiplier(100);
 


### PR DESCRIPTION
Sets the initial multiplier to 300 (4x). Hence, staking pool rewards get a 300% additional GHNY mint