### PR TITLE
allow refs to be set in each freezing tx if the ref is not set yet

### DIFF
--- a/contracts/FreezerV2.sol
+++ b/contracts/FreezerV2.sol
@@ -136,7 +136,7 @@ contract FreezerV2 is Initializable, FreezerBase {
 
         participantData[_for].level = _level;
 
-        if (referrals[_for] == address(0) && _depositedBefore == 0) {
+        if (referrals[_for] == address(0)) {
             referrals[_for] = _referral;
         }
 

--- a/test/FreezerV2.ts
+++ b/test/FreezerV2.ts
@@ -511,7 +511,7 @@ describe("FreezerV2", function () {
         await FreezerInstance.connect(signer).freeze(await signer.getAddress(), depositAmount, await otherSigner.getAddress());
 
         const referralReward2 = await FreezerInstance.referralRewards(await otherSigner.getAddress());
-        expect(referralReward2).to.equal(ethers.utils.parseEther("0"));
+        expect(referralReward2).to.equal(ethers.utils.parseEther("0.01"));
     });
 
     it("Can only set referral first time with other msg sender", async function () {


### PR DESCRIPTION
- The logic was that a ref can only be set for the first freezing. This condition is now relaxed such that a referral can be set only if the referral is not set yet (address zero)